### PR TITLE
Export public API explicitly for `mypy --strict` users

### DIFF
--- a/src/coolname/__init__.py
+++ b/src/coolname/__init__.py
@@ -6,3 +6,14 @@ from ._version import __version__, __version_tuple__
 from .exceptions import InitializationError
 from .impl import generate, generate_slug, get_combinations_count,\
     RandomGenerator, replace_random
+
+__all__ = [
+    "InitializationError",
+    "RandomGenerator",
+    "__version__",
+    "__version_tuple__",
+    "generate",
+    "generate_slug",
+    "get_combinations_count",
+    "replace_random",
+]


### PR DESCRIPTION
Add `__all__` in `__init__.py` so users running mypy with `--strict` (which includes `--no-implicit-reexport`) see `generate_slug` etc as exported names.