### PR TITLE
fix: __nocheck did not skip _check_not_hanging (operator precedence)

### DIFF
--- a/src/coolname/__init__.py
+++ b/src/coolname/__init__.py
@@ -100,7 +100,7 @@ class RandomGenerator:
         # Make sure that generate() does not go into long loop.
         # Default generator is a special case, we don't need check.
         if (not config['all'].get('__nocheck') and
-                self._ensure_unique or self._check_prefix or self._max_slug_length):
+                (self._ensure_unique or self._check_prefix or self._max_slug_length)):
             self._check_not_hanging()
         # Fire it up
         assert self.generate_slug()

--- a/tests/test_coolname.py
+++ b/tests/test_coolname.py
@@ -250,6 +250,26 @@ class TestCoolname(TestCase):
             RandomGenerator(config)
 
 
+    def test_nocheck_skips_hanging_check(self):
+        # __nocheck must skip _check_not_hanging() entirely. Due to operator
+        # precedence (and binds tighter than or), it previously only suppressed
+        # the ensure_unique branch, so the check still ran when
+        # ensure_unique_prefix / max_slug_length were set (as in the default
+        # config, which sets __nocheck precisely to skip this).
+        config = {
+            'all': {
+                'type': 'cartesian',
+                'lists': ['w1', 'w2'],
+                'max_slug_length': 50,
+                '__nocheck': True,
+            },
+            'w1': {'type': 'words', 'words': ['brave', 'agile']},
+            'w2': {'type': 'words', 'words': ['bravery', 'brass']},
+        }
+        with patch.object(RandomGenerator, '_check_not_hanging') as mock_check:
+            RandomGenerator(config)
+        mock_check.assert_not_called()
+
     def test_ensure_unique_prefix(self):
         config = {
             'all': {


### PR DESCRIPTION
## Problem

The `__nocheck` config flag is meant to skip the (relatively expensive) `_check_not_hanging()` rejection-sampling check — `_create_default_generator()` sets it precisely for this reason ("Default generator is a special case, we don't need check").

But the guard has an operator-precedence bug:

```python
if (not config['all'].get('__nocheck') and
        self._ensure_unique or self._check_prefix or self._max_slug_length):
    self._check_not_hanging()
```

Since `and` binds tighter than `or`, this parses as:

```python
if (not __nocheck and self._ensure_unique) or self._check_prefix or self._max_slug_length:
```

So `__nocheck` only suppresses the `ensure_unique` branch. When `ensure_unique_prefix` or `max_slug_length` is set, the check runs **even with `__nocheck=True`**.

This is not hypothetical: the bundled default config (`data/config.json`) sets `ensure_unique_prefix: 4` and `max_slug_length: 50`, so the default generator runs `_check_not_hanging()` (100 rejection-sampling iterations per generator list) on **every `import coolname`**, despite `__nocheck` being set to avoid exactly that.

## Fix

Parenthesize the `or` group so `__nocheck` suppresses the whole check, as intended:

```python
if (not config['all'].get('__nocheck') and
        (self._ensure_unique or self._check_prefix or self._max_slug_length)):
    self._check_not_hanging()
```

## Tests

Added `test_nocheck_skips_hanging_check`: with `__nocheck=True` and `max_slug_length` set, `_check_not_hanging` must not be called. It fails on `master` (called once) and passes with the fix. Existing tests unchanged.
